### PR TITLE
fix bakery crash when interval is not configured

### DIFF
--- a/bakery/fail2ban.py
+++ b/bakery/fail2ban.py
@@ -35,13 +35,11 @@ def get_fail2ban_plugin_files(conf: Fail2BanConfig) -> FileGenerator:
     Yields:
        Iterator[FileGenerator]: _description_
     """
-    interval = conf.get('interval')
-
     yield Plugin(
       base_os=OS.LINUX,
       source=Path('fail2ban.sh'),
       target=Path('fail2ban.sh'),
-      interval = int(interval),
+      interval = int(conf.get('interval', 300)),
     )
 
 register.bakery_plugin(


### PR DESCRIPTION
conf.get('interval') returns None when no interval is set in the bakery rule, causing int(None) to crash. Default to 300s (5 min).